### PR TITLE
fix: only run go checks to repo that has a /go.mod

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
     - name: Is it a go project?
       id: isGoProject
       run: |
-        if [ -n "$(find . -name '*.go')" ] ; then
+        if [ -e ./go.mod ] ; then
           echo "go=YES" >> $GITHUB_OUTPUT
         fi
       shell: bash


### PR DESCRIPTION
Signed-off-by: black-desk <me@black-desk.cn>
